### PR TITLE
🎉 Drop dependency on std library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ criterion = "^0.3.5"
 serde = { version = "^1.0.90", features = ["derive"] }
 
 [dependencies]
-byteorder = "^1.3.1"
 log = "^0.4.14"
 
 [[bench]]

--- a/benches/encoding.rs
+++ b/benches/encoding.rs
@@ -1,3 +1,5 @@
+extern crate std;
+
 use std::fs;
 
 use alac_encoder::{AlacEncoder, FormatDescription, MAX_ESCAPE_HEADER_BYTES};

--- a/src/ag.rs
+++ b/src/ag.rs
@@ -1,6 +1,6 @@
 //! Adaptive Golomb
 
-use std::cmp;
+use core::cmp;
 
 use crate::bit_buffer::BitBuffer;
 

--- a/src/bit_buffer.rs
+++ b/src/bit_buffer.rs
@@ -18,12 +18,12 @@ impl<'a> BitBuffer<'a> {
         let target = unsafe { self.buffer.as_mut_ptr().offset((self.position >> 3) as isize) as *mut u32 };
         let shift = 32 - ((self.position as u32) & 7) - num_bits;
 
-        let curr = u32::from_be(unsafe { std::ptr::read_unaligned(target) });
+        let curr = u32::from_be(unsafe { core::ptr::read_unaligned(target) });
 
         let mask = ((!0u32) >> (32 - num_bits)) << shift;
         let main = ((bit_values << shift) & mask) | (curr & !mask);
 
-        unsafe { std::ptr::write_unaligned(target, main.to_be()); }
+        unsafe { core::ptr::write_unaligned(target, main.to_be()); }
 
         self.position += num_bits as usize;
     }
@@ -34,20 +34,20 @@ impl<'a> BitBuffer<'a> {
         let target = unsafe { self.buffer.as_mut_ptr().offset((self.position >> 3) as isize) as *mut u32 };
         let shift = (32 - ((self.position as i32) & 7) - (num_bits as i32)) as i32;
 
-        let curr = u32::from_be(unsafe { std::ptr::read_unaligned(target) });
+        let curr = u32::from_be(unsafe { core::ptr::read_unaligned(target) });
 
         if shift < 0 {
             let mask = (!0u32) >> -shift;
             let main = (bit_values >> -shift) | (curr & !mask);
             let tail = ((bit_values << ((8 + shift))) & 0xff) as u8;
 
-            unsafe { std::ptr::write_unaligned(target, main.to_be()); }
-            unsafe { std::ptr::write_unaligned(target.offset(1) as *mut u8, tail); }
+            unsafe { core::ptr::write_unaligned(target, main.to_be()); }
+            unsafe { core::ptr::write_unaligned(target.offset(1) as *mut u8, tail); }
         } else {
             let mask = ((!0u32) >> (32 - num_bits)) << shift;
             let main = ((bit_values << shift) & mask) | (curr & !mask);
 
-            unsafe { std::ptr::write_unaligned(target, main.to_be()); }
+            unsafe { core::ptr::write_unaligned(target, main.to_be()); }
         }
 
         self.position += num_bits as usize;

--- a/src/dp.rs
+++ b/src/dp.rs
@@ -1,6 +1,6 @@
 //! Dynamic Predictor
 
-use std::num::Wrapping;
+use core::num::Wrapping;
 
 const AINIT: i32 = 38;
 const BINIT: i32 = -29;
@@ -22,7 +22,7 @@ trait Signed {
 
 impl Signed for i32 {
     fn sign(&self) -> Sign {
-        unsafe { std::mem::transmute(self.signum()) }
+        unsafe { core::mem::transmute(self.signum()) }
     }
 }
 


### PR DESCRIPTION
As suggested in the [Rust 1.36 release notes](https://blog.rust-lang.org/2019/07/04/Rust-1.36.0.html#the-alloc-crate-is-stable)