### PR TITLE
💥 Fix max packet size calculations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         rust:
           - beta
           - stable
-          - 1.56.0
+          - 1.57.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "alac-encoder"
 version = "0.2.0"
 authors = ["Linus Unnebäck <linus@folkdatorn.se>"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 description = "Rust port of Apple's open source ALAC library"
 repository = "https://github.com/LinusU/rust-alac-encoder"

--- a/benches/encoding.rs
+++ b/benches/encoding.rs
@@ -2,7 +2,7 @@ extern crate std;
 
 use std::fs;
 
-use alac_encoder::{AlacEncoder, FormatDescription, MAX_ESCAPE_HEADER_BYTES};
+use alac_encoder::{AlacEncoder, FormatDescription};
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 
 fn test_case (input: &[u8], output: &mut [u8], sample_rate: f64, frame_size: u32, channels: u32) {
@@ -23,7 +23,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         const SAMPLE_RATE: f64 = 44100.0;
         const FRAME_SIZE: u32 = 352;
         const CHANNELS: u32 = 2;
-        const BUFFER_SIZE: usize = (FRAME_SIZE as usize * CHANNELS as usize * 2) + MAX_ESCAPE_HEADER_BYTES;
+        const BUFFER_SIZE: usize = FormatDescription::alac(SAMPLE_RATE, FRAME_SIZE, CHANNELS).max_packet_size();
 
         let input = fs::read("fixtures/like-a-rolling-stone.pcm").unwrap();
         let mut output = vec![0u8; BUFFER_SIZE];

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ This crate works with Cargo and is on [crates.io](https://crates.io/crates/alac-
 ## Usage
 
 ```rust
-use alac_encoder::{AlacEncoder, FormatDescription, MAX_ESCAPE_HEADER_BYTES};
+use alac_encoder::{AlacEncoder, FormatDescription};
 
 // Specify the input format as signed 16-bit raw PCM, 44100 Hz & 2 channels
 let input_format = FormatDescription::pcm::<i16>(44100.0, 2);
@@ -21,8 +21,7 @@ let output_format = FormatDescription::alac(44100.0, 4096, 2);
 let mut encoder = AlacEncoder::new(&output_format);
 
 // Allocate a buffer for the encoder to write chunks to.
-// The smallest size of one chunk is (frame size * channels * bit depth in bytes) + max escape header bytes.
-let mut output = vec![0u8; (4096 * 2 * 2) + MAX_ESCAPE_HEADER_BYTES];
+let mut output = vec![0u8; output_format.max_packet_size()];
 
 // Get a hold of the source data, e.g. from a file
 let pcm = fs::read("foobar.pcm").unwrap();

--- a/src/ag.rs
+++ b/src/ag.rs
@@ -100,7 +100,7 @@ fn dyn_code_32bit(bitstream: &mut BitBuffer, maxbits: usize, m: u32, k: u32, n: 
 }
 
 pub fn dyn_comp(params: &AgParams, pc: &[i32], bitstream: &mut BitBuffer, num_samples: usize, bit_size: usize) {
-    assert!(bit_size > 0 && bit_size <= 32);
+    debug_assert!(bit_size > 0 && bit_size <= 32);
 
     let mut mb: u32 = params.mb;
     let pb: u32 = params.pb;
@@ -123,7 +123,7 @@ pub fn dyn_comp(params: &AgParams, pc: &[i32], bitstream: &mut BitBuffer, num_sa
         row_pos += 1;
 
         let n: u32 = ((del.abs() << 1) - ((del >> 31) & 1)) as u32 - zmode;
-        assert!(32 - n.leading_zeros() <= bit_size as u32);
+        debug_assert!(32 - n.leading_zeros() <= bit_size as u32);
 
         dyn_code_32bit(bitstream, bit_size, m, k, n);
 
@@ -142,7 +142,7 @@ pub fn dyn_comp(params: &AgParams, pc: &[i32], bitstream: &mut BitBuffer, num_sa
 
         zmode = 0;
 
-        assert!(c <= num_samples);
+        debug_assert!(c <= num_samples);
 
         if ((mb << MMULSHIFT) < QB) && (c < num_samples) {
             zmode = 1;

--- a/src/ag.rs
+++ b/src/ag.rs
@@ -67,7 +67,7 @@ fn dyn_code(bitstream: &mut BitBuffer, m: u32, k: u32, n: u32) {
 
         // use this result if coding this way is smaller than doing escape
         if num_bits <= (MAX_PREFIX_16 + MAX_DATATYPE_BITS_16) {
-            bitstream.write_lte25(value, num_bits);
+            bitstream.write_lte25(value, num_bits as usize);
             return;
         }
     }
@@ -75,12 +75,12 @@ fn dyn_code(bitstream: &mut BitBuffer, m: u32, k: u32, n: u32) {
     let num_bits = MAX_PREFIX_16 + MAX_DATATYPE_BITS_16;
     let value = (((1 << MAX_PREFIX_16) - 1) << MAX_DATATYPE_BITS_16) + n;
 
-    bitstream.write_lte25(value, num_bits);
+    bitstream.write_lte25(value, num_bits as usize);
 }
 
 #[inline(always)]
 fn dyn_code_32bit(bitstream: &mut BitBuffer, maxbits: usize, m: u32, k: u32, n: u32) {
-    let division = (n / m) as u32;
+    let division = n / m;
 
     if division < MAX_PREFIX_32 {
         let modulo: u32 = n - (m * division);
@@ -90,13 +90,13 @@ fn dyn_code_32bit(bitstream: &mut BitBuffer, maxbits: usize, m: u32, k: u32, n: 
         let value = (((1<<division)-1)<<(num_bits-division)) + modulo + 1 - de;
 
         if num_bits <= 25 {
-            bitstream.write_lte25(value, num_bits);
+            bitstream.write_lte25(value, num_bits as usize);
             return;
         }
     }
 
-    bitstream.write_lte25((1 << MAX_PREFIX_32) - 1, MAX_PREFIX_32);
-    bitstream.write(n, maxbits as u32);
+    bitstream.write_lte25((1 << MAX_PREFIX_32) - 1, MAX_PREFIX_32 as usize);
+    bitstream.write(n, maxbits);
 }
 
 pub fn dyn_comp(params: &AgParams, pc: &[i32], bitstream: &mut BitBuffer, num_samples: usize, bit_size: usize) {

--- a/src/bit_buffer.rs
+++ b/src/bit_buffer.rs
@@ -12,12 +12,12 @@ impl<'a> BitBuffer<'a> {
         self.buffer.len()
     }
 
-    pub fn write_lte25(&mut self, bit_values: u32, num_bits: u32) {
+    pub fn write_lte25(&mut self, bit_values: u32, num_bits: usize) {
         debug_assert!(num_bits > 0 && num_bits <= 25);
-        debug_assert!(self.position + (num_bits as usize) <= self.buffer.len() * 8);
+        debug_assert!(self.position + num_bits <= self.buffer.len() * 8);
 
         let target = unsafe { self.buffer.as_mut_ptr().add(self.position >> 3) as *mut u32 };
-        let shift = 32 - ((self.position as u32) & 7) - num_bits;
+        let shift = 32 - (self.position & 7) - num_bits;
 
         let curr = u32::from_be(unsafe { core::ptr::read_unaligned(target) });
 
@@ -26,12 +26,12 @@ impl<'a> BitBuffer<'a> {
 
         unsafe { core::ptr::write_unaligned(target, main.to_be()); }
 
-        self.position += num_bits as usize;
+        self.position += num_bits;
     }
 
-    pub fn write(&mut self, bit_values: u32, num_bits: u32) {
+    pub fn write(&mut self, bit_values: u32, num_bits: usize) {
         debug_assert!(num_bits > 0 && num_bits <= 32);
-        debug_assert!(self.position + (num_bits as usize) <= self.buffer.len() * 8);
+        debug_assert!(self.position + num_bits <= self.buffer.len() * 8);
 
         let target = unsafe { self.buffer.as_mut_ptr().add(self.position >> 3) as *mut u32 };
         let shift = (32 - ((self.position as i32) & 7) - (num_bits as i32)) as i32;
@@ -52,12 +52,12 @@ impl<'a> BitBuffer<'a> {
             unsafe { core::ptr::write_unaligned(target, main.to_be()); }
         }
 
-        self.position += num_bits as usize;
+        self.position += num_bits;
     }
 
     /// Align bit buffer to next byte boundary, writing zeros if requested
     pub fn byte_align(&mut self) {
-        let bit = (self.position & 7) as u32;
+        let bit = self.position & 7;
 
         if bit == 0 { return; }
 

--- a/src/bit_buffer.rs
+++ b/src/bit_buffer.rs
@@ -13,7 +13,8 @@ impl<'a> BitBuffer<'a> {
     }
 
     pub fn write_lte25(&mut self, bit_values: u32, num_bits: u32) {
-        assert!(num_bits > 0 && num_bits <= 25);
+        debug_assert!(num_bits > 0 && num_bits <= 25);
+        debug_assert!(self.position + (num_bits as usize) <= self.buffer.len() * 8);
 
         let target = unsafe { self.buffer.as_mut_ptr().add(self.position >> 3) as *mut u32 };
         let shift = 32 - ((self.position as u32) & 7) - num_bits;
@@ -29,7 +30,8 @@ impl<'a> BitBuffer<'a> {
     }
 
     pub fn write(&mut self, bit_values: u32, num_bits: u32) {
-        assert!(num_bits > 0 && num_bits <= 32);
+        debug_assert!(num_bits > 0 && num_bits <= 32);
+        debug_assert!(self.position + (num_bits as usize) <= self.buffer.len() * 8);
 
         let target = unsafe { self.buffer.as_mut_ptr().add(self.position >> 3) as *mut u32 };
         let shift = (32 - ((self.position as i32) & 7) - (num_bits as i32)) as i32;

--- a/src/bit_buffer.rs
+++ b/src/bit_buffer.rs
@@ -15,7 +15,7 @@ impl<'a> BitBuffer<'a> {
     pub fn write_lte25(&mut self, bit_values: u32, num_bits: u32) {
         assert!(num_bits > 0 && num_bits <= 25);
 
-        let target = unsafe { self.buffer.as_mut_ptr().offset((self.position >> 3) as isize) as *mut u32 };
+        let target = unsafe { self.buffer.as_mut_ptr().add(self.position >> 3) as *mut u32 };
         let shift = 32 - ((self.position as u32) & 7) - num_bits;
 
         let curr = u32::from_be(unsafe { core::ptr::read_unaligned(target) });
@@ -31,7 +31,7 @@ impl<'a> BitBuffer<'a> {
     pub fn write(&mut self, bit_values: u32, num_bits: u32) {
         assert!(num_bits > 0 && num_bits <= 32);
 
-        let target = unsafe { self.buffer.as_mut_ptr().offset((self.position >> 3) as isize) as *mut u32 };
+        let target = unsafe { self.buffer.as_mut_ptr().add(self.position >> 3) as *mut u32 };
         let shift = (32 - ((self.position as i32) & 7) - (num_bits as i32)) as i32;
 
         let curr = u32::from_be(unsafe { core::ptr::read_unaligned(target) });
@@ -39,7 +39,7 @@ impl<'a> BitBuffer<'a> {
         if shift < 0 {
             let mask = (!0u32) >> -shift;
             let main = (bit_values >> -shift) | (curr & !mask);
-            let tail = ((bit_values << ((8 + shift))) & 0xff) as u8;
+            let tail = ((bit_values << (8 + shift)) & 0xff) as u8;
 
             unsafe { core::ptr::write_unaligned(target, main.to_be()); }
             unsafe { core::ptr::write_unaligned(target.offset(1) as *mut u8, tail); }
@@ -54,19 +54,12 @@ impl<'a> BitBuffer<'a> {
     }
 
     /// Align bit buffer to next byte boundary, writing zeros if requested
-    pub fn byte_align(&mut self, add_zeros: bool) {
+    pub fn byte_align(&mut self) {
         let bit = (self.position & 7) as u32;
 
         if bit == 0 { return; }
 
-        match add_zeros {
-            true => self.write_lte25(0, 8 - bit),
-            false => self.advance(8 - bit),
-        }
-    }
-
-    pub fn advance(&mut self, num_bits: u32) {
-        self.position += num_bits as usize;
+        self.write_lte25(0, 8 - bit);
     }
 
     pub fn position(&self) -> usize {

--- a/src/dp.rs
+++ b/src/dp.rs
@@ -26,16 +26,13 @@ impl Signed for i32 {
     }
 }
 
+/// Note: Assumes that the input coefs is already zeroed out
 pub fn init_coefs(coefs: &mut [i16], denshift: u32) {
     let den = 1i32 << denshift;
 
     coefs[0] = ((AINIT * den) >> 4) as i16;
     coefs[1] = ((BINIT * den) >> 4) as i16;
     coefs[2] = ((CINIT * den) >> 4) as i16;
-
-    for index in 3..coefs.len() {
-        coefs[index] = 0;
-    }
 }
 
 pub fn pc_block(input: &[i32], pc1: &mut [i32], num: usize, coefs: &mut [i16], numactive: usize, chanbits: usize, denshift: u32) {
@@ -90,17 +87,17 @@ pub fn pc_block(input: &[i32], pc1: &mut [i32], num: usize, coefs: &mut [i16], n
                     Sign::Positive => {
                         let sgn = b3.signum();
                         a3 -= sgn as i16;
-                        del -= (4 - 3) * ((sgn * b3) >> denshift);
+                        del -= (sgn * b3) >> denshift;
                         if del <= 0 { continue; }
 
                         let sgn = b2.signum();
                         a2 -= sgn as i16;
-                        del -= (4 - 2) * ((sgn * b2) >> denshift);
+                        del -= 2 * ((sgn * b2) >> denshift);
                         if del <= 0 { continue; }
 
                         let sgn = b1.signum();
                         a1 -= sgn as i16;
-                        del -= (4 - 1) * ((sgn * b1) >> denshift);
+                        del -= 3 * ((sgn * b1) >> denshift);
                         if del <= 0 { continue; }
 
                         a0 -= b0.signum() as i16;
@@ -109,17 +106,17 @@ pub fn pc_block(input: &[i32], pc1: &mut [i32], num: usize, coefs: &mut [i16], n
                         // note: to avoid unnecessary negations, we flip the value of "sgn"
                         let sgn = -(b3.signum());
                         a3 -= sgn as i16;
-                        del -= (4 - 3) * ((sgn * b3) >> denshift);
+                        del -= (sgn * b3) >> denshift;
                         if del >= 0 { continue; }
 
                         let sgn = -(b2.signum());
                         a2 -= sgn as i16;
-                        del -= (4 - 2) * ((sgn * b2) >> denshift);
+                        del -= 2 * ((sgn * b2) >> denshift);
                         if del >= 0 { continue; }
 
                         let sgn = -(b1.signum());
                         a1 -= sgn as i16;
-                        del -= (4 - 1) * ((sgn * b1) >> denshift);
+                        del -= 3 * ((sgn * b1) >> denshift);
                         if del >= 0 { continue; }
 
                         a0 += b0.signum() as i16;
@@ -165,7 +162,7 @@ pub fn pc_block(input: &[i32], pc1: &mut [i32], num: usize, coefs: &mut [i16], n
                     Sign::Positive => {
                         let sgn = b7.signum();
                         a7 -= sgn as i16;
-                        del -= 1 * ((sgn * b7) >> denshift);
+                        del -= (sgn * b7) >> denshift;
                         if del <= 0 { continue; }
 
                         let sgn = b6.signum();
@@ -204,7 +201,7 @@ pub fn pc_block(input: &[i32], pc1: &mut [i32], num: usize, coefs: &mut [i16], n
                         // note: to avoid unnecessary negations, we flip the value of "sgn"
                         let sgn = -(b7.signum());
                         a7 -= sgn as i16;
-                        del -= 1 * ((sgn * b7) >> denshift);
+                        del -= (sgn * b7) >> denshift;
                         if del >= 0 { continue; }
 
                         let sgn = -(b6.signum());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,9 +358,9 @@ impl AlacEncoder {
 
         // pick bit depth for actual encoding
         // - we lop off the lower byte(s) for 24-/32-bit encodings
-        let bytes_shifted: u8 = match self.bit_depth { 32 => 2, 24 => 1, _ => 0 };
+        let bytes_shifted: usize = match self.bit_depth { 32 => 2, 24 => 1, _ => 0 };
 
-        let shift = (bytes_shifted as usize) * 8;
+        let shift = bytes_shifted * 8;
         let mask: u32 = (1u32 << shift) - 1;
         let chan_bits = self.bit_depth - shift;
 
@@ -434,7 +434,7 @@ impl AlacEncoder {
         // - first, add bits for the header bytes mixRes/maxRes/shiftU/filterU
         min_bits += (4 /* mixRes/maxRes/etc. */ * 8) + (if partial_frame == (true as u8) { 32 } else { 0 });
         if bytes_shifted != 0 {
-            min_bits += num_samples * ((bytes_shifted as usize) * 8);
+            min_bits += num_samples * bytes_shifted * 8;
         }
 
         let escape_bits = (num_samples * self.bit_depth) + (if partial_frame == (true as u8) { 32 } else { 0 }) + (2 * 8); /* 2 common header bytes */
@@ -586,7 +586,7 @@ impl AlacEncoder {
         // matrix encoding adds an extra bit but 32-bit inputs cannot be matrixed b/c 33 is too many
         // so enable 16-bit "shift off" and encode in 17-bit mode
         // - in addition, 24-bit mode really improves with one byte shifted off
-        let bytes_shifted: u8 = match self.bit_depth { 32 => 2, 24 => 1, _ => 0 };
+        let bytes_shifted: usize = match self.bit_depth { 32 => 2, 24 => 1, _ => 0 };
 
         let chan_bits: u32 = (self.bit_depth as u32) - (bytes_shifted as u32 * 8) + 1;
 
@@ -707,7 +707,7 @@ impl AlacEncoder {
         // test for escape hatch if best calculated compressed size turns out to be more than the input size
         let mut min_bits = min_bits1 + min_bits2 + (8 /* mixRes/maxRes/etc. */ * 8) + (if partial_frame == (true as u8) { 32 } else { 0 });
         if bytes_shifted != 0 {
-            min_bits += (num_samples) * ((bytes_shifted as usize) * 8) * 2;
+            min_bits += num_samples * bytes_shifted * 8 * 2;
         }
 
         let escape_bits = (num_samples * self.bit_depth * 2) + (if partial_frame == (true as u8) { 32 } else { 0 }) + (2 * 8); /* 2 common header bytes */
@@ -742,7 +742,7 @@ impl AlacEncoder {
 
             // if shift active, write the interleaved shift buffers
             if bytes_shifted != 0 {
-                let bit_shift = (bytes_shifted as usize) * 8;
+                let bit_shift = bytes_shifted * 8;
                 debug_assert!(bit_shift <= 16);
 
                 for index in (0..(num_samples * 2)).step_by(2) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,9 +360,9 @@ impl AlacEncoder {
         // - we lop off the lower byte(s) for 24-/32-bit encodings
         let bytes_shifted: u8 = match self.bit_depth { 32 => 2, 24 => 1, _ => 0 };
 
-        let shift: u32 = (bytes_shifted as u32) * 8;
+        let shift = (bytes_shifted as usize) * 8;
         let mask: u32 = (1u32 << shift) - 1;
-        let chan_bits: u32 = (self.bit_depth as u32) - shift;
+        let chan_bits = self.bit_depth - shift;
 
         // flag whether or not this is a partial frame
         let partial_frame: u8 = if num_samples == self.frame_size { 0 } else { 1 };
@@ -742,7 +742,7 @@ impl AlacEncoder {
 
             // if shift active, write the interleaved shift buffers
             if bytes_shifted != 0 {
-                let bit_shift: u32 = (bytes_shifted as u32) * 8;
+                let bit_shift = (bytes_shifted as usize) * 8;
                 debug_assert!(bit_shift <= 16);
 
                 for index in (0..(num_samples * 2)).step_by(2) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,8 +359,8 @@ impl AlacEncoder {
         bitstream.byte_align();
 
         let output_size = bitstream.position() / 8;
-        assert!(output_size <= bitstream.len());
-        assert!(output_size <= self.max_output_bytes);
+        debug_assert!(output_size <= bitstream.len());
+        debug_assert!(output_size <= self.max_output_bytes);
 
         self.total_bytes_generated += output_size;
         self.max_frame_bytes = core::cmp::max(self.max_frame_bytes, output_size as u32);
@@ -742,9 +742,9 @@ impl AlacEncoder {
             bitstream.write_lte25(mix_bits as u32, 8);
             bitstream.write_lte25(mix_res as u32, 8);
 
-            assert!((mode < 16) && (dp::DENSHIFT_DEFAULT < 16));
-            assert!((pb_factor < 8) && (num_u < 32));
-            assert!((pb_factor < 8) && (num_v < 32));
+            debug_assert!((mode < 16) && (dp::DENSHIFT_DEFAULT < 16));
+            debug_assert!((pb_factor < 8) && (num_u < 32));
+            debug_assert!((pb_factor < 8) && (num_v < 32));
 
             bitstream.write_lte25((mode << 4) | dp::DENSHIFT_DEFAULT, 8);
             bitstream.write_lte25((pb_factor << 5) | (num_u as u32), 8);
@@ -761,7 +761,7 @@ impl AlacEncoder {
             // if shift active, write the interleaved shift buffers
             if bytes_shifted != 0 {
                 let bit_shift: u32 = (bytes_shifted as u32) * 8;
-                assert!(bit_shift <= 16);
+                debug_assert!(bit_shift <= 16);
 
                 for index in (0..(num_samples * 2)).step_by(2) {
                     let shifted_val: u32 = ((self.shift_buffer_uv[index] as u32) << bit_shift) | (self.shift_buffer_uv[index + 1] as u32);

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -66,7 +66,7 @@ pub fn mix20(input: Source, u: &mut [i32], v: &mut [i32], mixbits: i32, mixres: 
 // 24-bit routines
 // - 24-bit data sometimes compresses better by shifting off the bottom byte so these routines deal with
 //	 the specified "unused lower bytes" in the combined "shift" buffer
-pub fn mix24(input: Source, u: &mut [i32], v: &mut [i32], mixbits: i32, mixres: i32, shift_uv: &mut [u16], bytes_shifted: u8) {
+pub fn mix24(input: Source, u: &mut [i32], v: &mut [i32], mixbits: i32, mixres: i32, shift_uv: &mut [u16], bytes_shifted: usize) {
     debug_assert!(bytes_shifted <= 2);
 
     let shift = bytes_shifted * 8;
@@ -126,7 +126,7 @@ pub fn mix24(input: Source, u: &mut [i32], v: &mut [i32], mixbits: i32, mixres: 
 // - note that these really expect the internal data width to be < 32-bit but the arrays are 32-bit
 // - otherwise, the calculations might overflow into the 33rd bit and be lost
 // - therefore, these routines deal with the specified "unused lower" bytes in the combined "shift" buffer
-pub fn mix32(input: Source, u: &mut [i32], v: &mut [i32], mixbits: i32, mixres: i32, shift_uv: &mut [u16], bytes_shifted: u8) {
+pub fn mix32(input: Source, u: &mut [i32], v: &mut [i32], mixbits: i32, mixres: i32, shift_uv: &mut [u16], bytes_shifted: usize) {
     debug_assert!(bytes_shifted <= 2);
 
     let shift = bytes_shifted * 8;

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -13,46 +13,52 @@
 // L = u + v - [rV/m];
 // R = L - v;
 
-pub fn mix16(input: &[u8], stride: usize, u: &mut [i32], v: &mut [i32], num_samples: usize, mixbits: i32, mixres: i32) {
+pub struct Source<'a> {
+    pub data: &'a [u8],
+    pub stride: usize,
+    pub num_samples: usize,
+}
+
+pub fn mix16(input: Source, u: &mut [i32], v: &mut [i32], mixbits: i32, mixres: i32) {
     if mixres != 0 {
         /* matrixed stereo */
         let modulo: i32 = 1 << mixbits;
         let m2: i32 = modulo - mixres;
 
-        for j in 0..num_samples {
-            let l = i16::from_le_bytes([input[j * stride * 2 + 0], input[j * stride * 2 + 1]]) as i32;
-            let r = i16::from_le_bytes([input[j * stride * 2 + 2], input[j * stride * 2 + 3]]) as i32;
+        for j in 0..input.num_samples {
+            let l = i16::from_le_bytes([input.data[j * input.stride * 2], input.data[j * input.stride * 2 + 1]]) as i32;
+            let r = i16::from_le_bytes([input.data[j * input.stride * 2 + 2], input.data[j * input.stride * 2 + 3]]) as i32;
 
             u[j] = (mixres * l + m2 * r) >> mixbits;
             v[j] = l - r;
         }
     } else {
         /* Conventional separated stereo. */
-        for j in 0..num_samples {
-            u[j] = i16::from_le_bytes([input[j * stride * 2 + 0], input[j * stride * 2 + 1]]) as i32;
-            v[j] = i16::from_le_bytes([input[j * stride * 2 + 2], input[j * stride * 2 + 3]]) as i32;
+        for j in 0..input.num_samples {
+            u[j] = i16::from_le_bytes([input.data[j * input.stride * 2], input.data[j * input.stride * 2 + 1]]) as i32;
+            v[j] = i16::from_le_bytes([input.data[j * input.stride * 2 + 2], input.data[j * input.stride * 2 + 3]]) as i32;
         }
     }
 }
 
-pub fn mix20(input: &[u8], stride: usize, u: &mut [i32], v: &mut [i32], num_samples: usize, mixbits: i32, mixres: i32) {
+pub fn mix20(input: Source, u: &mut [i32], v: &mut [i32], mixbits: i32, mixres: i32) {
     if mixres != 0 {
         /* matrixed stereo */
         let modulo: i32 = 1 << mixbits;
         let m2: i32 = modulo - mixres;
 
-        for j in 0..num_samples {
-            let l = (i32::from_be_bytes([0, input[j * stride * 3 + 0], input[j * stride * 3 + 1], input[j * stride * 3 + 2]]) << 8) >> 12;
-            let r = (i32::from_be_bytes([0, input[j * stride * 3 + 3], input[j * stride * 3 + 4], input[j * stride * 3 + 5]]) << 8) >> 12;
+        for j in 0..input.num_samples {
+            let l = (i32::from_be_bytes([0, input.data[j * input.stride * 3], input.data[j * input.stride * 3 + 1], input.data[j * input.stride * 3 + 2]]) << 8) >> 12;
+            let r = (i32::from_be_bytes([0, input.data[j * input.stride * 3 + 3], input.data[j * input.stride * 3 + 4], input.data[j * input.stride * 3 + 5]]) << 8) >> 12;
 
             u[j] = (mixres * l + m2 * r) >> mixbits;
             v[j] = l - r;
         }
     } else {
         /* Conventional separated stereo. */
-        for j in 0..num_samples {
-            u[j] = (i32::from_be_bytes([0, input[j * stride * 3 + 0], input[j * stride * 3 + 1], input[j * stride * 3 + 2]]) << 8) >> 12;
-            v[j] = (i32::from_be_bytes([0, input[j * stride * 3 + 3], input[j * stride * 3 + 4], input[j * stride * 3 + 5]]) << 8) >> 12;
+        for j in 0..input.num_samples {
+            u[j] = (i32::from_be_bytes([0, input.data[j * input.stride * 3], input.data[j * input.stride * 3 + 1], input.data[j * input.stride * 3 + 2]]) << 8) >> 12;
+            v[j] = (i32::from_be_bytes([0, input.data[j * input.stride * 3 + 3], input.data[j * input.stride * 3 + 4], input.data[j * input.stride * 3 + 5]]) << 8) >> 12;
         }
     }
 }
@@ -60,7 +66,9 @@ pub fn mix20(input: &[u8], stride: usize, u: &mut [i32], v: &mut [i32], num_samp
 // 24-bit routines
 // - 24-bit data sometimes compresses better by shifting off the bottom byte so these routines deal with
 //	 the specified "unused lower bytes" in the combined "shift" buffer
-pub fn mix24(input: &[u8], stride: usize, u: &mut [i32], v: &mut [i32], num_samples: usize, mixbits: i32, mixres: i32, shift_uv: &mut [u16], bytes_shifted: i32) {
+pub fn mix24(input: Source, u: &mut [i32], v: &mut [i32], mixbits: i32, mixres: i32, shift_uv: &mut [u16], bytes_shifted: u8) {
+    debug_assert!(bytes_shifted <= 2);
+
     let shift = bytes_shifted * 8;
     let mask = (1u32 << shift) - 1;
 
@@ -70,11 +78,11 @@ pub fn mix24(input: &[u8], stride: usize, u: &mut [i32], v: &mut [i32], num_samp
         let m2 = modulo - mixres;
 
         if bytes_shifted != 0 {
-            for j in 0..num_samples {
-                let l = (i32::from_be_bytes([0, input[j * stride * 3 + 0], input[j * stride * 3 + 1], input[j * stride * 3 + 2]]) << 8) >> 8;
-                let r = (i32::from_be_bytes([0, input[j * stride * 3 + 3], input[j * stride * 3 + 4], input[j * stride * 3 + 5]]) << 8) >> 8;
+            for j in 0..input.num_samples {
+                let l = (i32::from_be_bytes([0, input.data[j * input.stride * 3], input.data[j * input.stride * 3 + 1], input.data[j * input.stride * 3 + 2]]) << 8) >> 8;
+                let r = (i32::from_be_bytes([0, input.data[j * input.stride * 3 + 3], input.data[j * input.stride * 3 + 4], input.data[j * input.stride * 3 + 5]]) << 8) >> 8;
 
-                shift_uv[j * 2 + 0] = ((l as u32) & mask) as u16;
+                shift_uv[j * 2] = ((l as u32) & mask) as u16;
                 shift_uv[j * 2 + 1] = ((r as u32) & mask) as u16;
 
                 let l = l >> shift;
@@ -84,9 +92,9 @@ pub fn mix24(input: &[u8], stride: usize, u: &mut [i32], v: &mut [i32], num_samp
                 v[j] = l - r;
             }
         } else {
-            for j in 0..num_samples {
-                let l = (i32::from_be_bytes([0, input[j * stride * 3 + 0], input[j * stride * 3 + 1], input[j * stride * 3 + 2]]) << 8) >> 8;
-                let r = (i32::from_be_bytes([0, input[j * stride * 3 + 3], input[j * stride * 3 + 4], input[j * stride * 3 + 5]]) << 8) >> 8;
+            for j in 0..input.num_samples {
+                let l = (i32::from_be_bytes([0, input.data[j * input.stride * 3], input.data[j * input.stride * 3 + 1], input.data[j * input.stride * 3 + 2]]) << 8) >> 8;
+                let r = (i32::from_be_bytes([0, input.data[j * input.stride * 3 + 3], input.data[j * input.stride * 3 + 4], input.data[j * input.stride * 3 + 5]]) << 8) >> 8;
 
                 u[j] = (mixres * l + m2 * r) >> mixbits;
                 v[j] = l - r;
@@ -95,20 +103,20 @@ pub fn mix24(input: &[u8], stride: usize, u: &mut [i32], v: &mut [i32], num_samp
     } else {
         /* Conventional separated stereo. */
         if bytes_shifted != 0 {
-            for j in 0..num_samples {
-                let l = (i32::from_be_bytes([0, input[j * stride * 3 + 0], input[j * stride * 3 + 1], input[j * stride * 3 + 2]]) << 8) >> 8;
-                let r = (i32::from_be_bytes([0, input[j * stride * 3 + 3], input[j * stride * 3 + 4], input[j * stride * 3 + 5]]) << 8) >> 8;
+            for j in 0..input.num_samples {
+                let l = (i32::from_be_bytes([0, input.data[j * input.stride * 3], input.data[j * input.stride * 3 + 1], input.data[j * input.stride * 3 + 2]]) << 8) >> 8;
+                let r = (i32::from_be_bytes([0, input.data[j * input.stride * 3 + 3], input.data[j * input.stride * 3 + 4], input.data[j * input.stride * 3 + 5]]) << 8) >> 8;
 
-                shift_uv[j * 2 + 0] = ((l as u32) & mask) as u16;
+                shift_uv[j * 2] = ((l as u32) & mask) as u16;
                 shift_uv[j * 2 + 1] = ((r as u32) & mask) as u16;
 
                 u[j] = l >> shift;
                 v[j] = r >> shift;
             }
         } else {
-            for j in 0..num_samples {
-                u[j] = (i32::from_be_bytes([0, input[j * stride * 3 + 0], input[j * stride * 3 + 1], input[j * stride * 3 + 2]]) << 8) >> 8;
-                v[j] = (i32::from_be_bytes([0, input[j * stride * 3 + 3], input[j * stride * 3 + 4], input[j * stride * 3 + 5]]) << 8) >> 8;
+            for j in 0..input.num_samples {
+                u[j] = (i32::from_be_bytes([0, input.data[j * input.stride * 3], input.data[j * input.stride * 3 + 1], input.data[j * input.stride * 3 + 2]]) << 8) >> 8;
+                v[j] = (i32::from_be_bytes([0, input.data[j * input.stride * 3 + 3], input.data[j * input.stride * 3 + 4], input.data[j * input.stride * 3 + 5]]) << 8) >> 8;
             }
         }
     }
@@ -118,22 +126,24 @@ pub fn mix24(input: &[u8], stride: usize, u: &mut [i32], v: &mut [i32], num_samp
 // - note that these really expect the internal data width to be < 32-bit but the arrays are 32-bit
 // - otherwise, the calculations might overflow into the 33rd bit and be lost
 // - therefore, these routines deal with the specified "unused lower" bytes in the combined "shift" buffer
-pub fn mix32(input: &[u8], stride: usize, u: &mut [i32], v: &mut [i32], num_samples: usize, mixbits: i32, mixres: i32, shift_uv: &mut [u16], bytes_shifted: i32) {
+pub fn mix32(input: Source, u: &mut [i32], v: &mut [i32], mixbits: i32, mixres: i32, shift_uv: &mut [u16], bytes_shifted: u8) {
+    debug_assert!(bytes_shifted <= 2);
+
     let shift = bytes_shifted * 8;
     let mask = (1u32 << shift) - 1;
 
     if mixres != 0 {
-        assert!(bytes_shifted != 0);
+        debug_assert!(bytes_shifted != 0);
 
         /* matrixed stereo with shift */
         let modulo = 1 << mixbits;
         let m2 = modulo - mixres;
 
-        for j in 0..num_samples {
-            let l = i32::from_le_bytes([input[j * stride * 4 + 0], input[j * stride * 4 + 1], input[j * stride * 4 + 2], input[j * stride * 4 + 3]]);
-            let r = i32::from_le_bytes([input[j * stride * 4 + 4], input[j * stride * 4 + 5], input[j * stride * 4 + 6], input[j * stride * 4 + 7]]);
+        for j in 0..input.num_samples {
+            let l = i32::from_le_bytes([input.data[j * input.stride * 4], input.data[j * input.stride * 4 + 1], input.data[j * input.stride * 4 + 2], input.data[j * input.stride * 4 + 3]]);
+            let r = i32::from_le_bytes([input.data[j * input.stride * 4 + 4], input.data[j * input.stride * 4 + 5], input.data[j * input.stride * 4 + 6], input.data[j * input.stride * 4 + 7]]);
 
-            shift_uv[j * 2 + 0] = ((l as u32) & mask) as u16;
+            shift_uv[j * 2] = ((l as u32) & mask) as u16;
             shift_uv[j * 2 + 1] = ((r as u32) & mask) as u16;
 
             let l = l >> shift;
@@ -142,25 +152,23 @@ pub fn mix32(input: &[u8], stride: usize, u: &mut [i32], v: &mut [i32], num_samp
             u[j] = (mixres * l + m2 * r) >> mixbits;
             v[j] = l - r;
         }
+    } else if bytes_shifted != 0 {
+        /* de-interleaving with shift */
+        for j in 0..input.num_samples {
+            let l = i32::from_le_bytes([input.data[j * input.stride * 4], input.data[j * input.stride * 4 + 1], input.data[j * input.stride * 4 + 2], input.data[j * input.stride * 4 + 3]]);
+            let r = i32::from_le_bytes([input.data[j * input.stride * 4 + 4], input.data[j * input.stride * 4 + 5], input.data[j * input.stride * 4 + 6], input.data[j * input.stride * 4 + 7]]);
+
+            shift_uv[j * 2] = ((l as u32) & mask) as u16;
+            shift_uv[j * 2 + 1] = ((r as u32) & mask) as u16;
+
+            u[j] = l >> shift;
+            v[j] = r >> shift;
+        }
     } else {
-        if bytes_shifted != 0 {
-            /* de-interleaving with shift */
-            for j in 0..num_samples {
-                let l = i32::from_le_bytes([input[j * stride * 4 + 0], input[j * stride * 4 + 1], input[j * stride * 4 + 2], input[j * stride * 4 + 3]]);
-                let r = i32::from_le_bytes([input[j * stride * 4 + 4], input[j * stride * 4 + 5], input[j * stride * 4 + 6], input[j * stride * 4 + 7]]);
-
-                shift_uv[j * 2 + 0] = ((l as u32) & mask) as u16;
-                shift_uv[j * 2 + 1] = ((r as u32) & mask) as u16;
-
-                u[j] = l >> shift;
-                v[j] = r >> shift;
-            }
-        } else {
-            /* de-interleaving w/o shift */
-            for j in 0..num_samples {
-                u[j] = i32::from_le_bytes([input[j * stride * 4 + 0], input[j * stride * 4 + 1], input[j * stride * 4 + 2], input[j * stride * 4 + 3]]);
-                v[j] = i32::from_le_bytes([input[j * stride * 4 + 4], input[j * stride * 4 + 5], input[j * stride * 4 + 6], input[j * stride * 4 + 7]]);
-            }
+        /* de-interleaving w/o shift */
+        for j in 0..input.num_samples {
+            u[j] = i32::from_le_bytes([input.data[j * input.stride * 4], input.data[j * input.stride * 4 + 1], input.data[j * input.stride * 4 + 2], input.data[j * input.stride * 4 + 3]]);
+            v[j] = i32::from_le_bytes([input.data[j * input.stride * 4 + 4], input.data[j * input.stride * 4 + 5], input.data[j * input.stride * 4 + 6], input.data[j * input.stride * 4 + 7]]);
         }
     }
 }


### PR DESCRIPTION
Migration guide:

This change brings the minimum supported version of the Rust compiler up to 1.57.0.

Instead of using the `MAX_ESCAPE_HEADER_BYTES` constant to manually calculate the required output buffer size, this is now exposed as a function on the `FormatDescription` struct. Simply call `max_packet_size()` on your output format description struct.

This functions is a const fn, so it can be used in const contexts. In addition, the `FormatDescription::alac` constructor was also made const, so that the minimum output buffer size can be calculated at compile time.