### PR TITLE
🌹 Add more realistic benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/fixtures/like-a-rolling-stone.pcm
 /target
 **/*.rs.bk
 Cargo.lock

--- a/benches/encoding.rs
+++ b/benches/encoding.rs
@@ -5,29 +5,30 @@ use std::fs;
 use alac_encoder::{AlacEncoder, FormatDescription, MAX_ESCAPE_HEADER_BYTES};
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 
-fn test_case (input: &str, frame_size: u32, channels: u32) {
-    let input_format = FormatDescription::pcm::<i16>(44100.0, channels);
-    let output_format = FormatDescription::alac(44100.0, frame_size, channels);
+fn test_case (input: &[u8], output: &mut [u8], sample_rate: f64, frame_size: u32, channels: u32) {
+    let input_format = FormatDescription::pcm::<i16>(sample_rate, channels);
+    let output_format = FormatDescription::alac(sample_rate, frame_size, channels);
 
     let mut encoder = AlacEncoder::new(&output_format);
 
-    let pcm = fs::read(format!("fixtures/{}", input)).unwrap();
+    for chunk in input.chunks(frame_size as usize * channels as usize * 2) {
+        let size = encoder.encode(&input_format, chunk, output);
 
-    let mut output = vec![0u8; (frame_size as usize * channels as usize * 2) + MAX_ESCAPE_HEADER_BYTES];
-
-    for chunk in pcm.chunks(frame_size as usize * channels as usize * 2) {
-        let size = encoder.encode(&input_format, &chunk, &mut output);
-        black_box(Vec::from(&output[0..size]));
+        black_box(&output[0..size]);
     }
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("sample_352_2", |b| {
-        b.iter(|| test_case("sample.pcm", 352, 2));
-    });
+    c.bench_function("Like a Rolling Stone", |b| {
+        const SAMPLE_RATE: f64 = 44100.0;
+        const FRAME_SIZE: u32 = 352;
+        const CHANNELS: u32 = 2;
+        const BUFFER_SIZE: usize = (FRAME_SIZE as usize * CHANNELS as usize * 2) + MAX_ESCAPE_HEADER_BYTES;
 
-    c.bench_function("sample_4096_2", |b| {
-        b.iter(|| test_case("sample.pcm", 4096, 2));
+        let input = fs::read("fixtures/like-a-rolling-stone.pcm").unwrap();
+        let mut output = vec![0u8; BUFFER_SIZE];
+
+        b.iter(|| test_case(&input, &mut output, SAMPLE_RATE, FRAME_SIZE, CHANNELS));
     });
 }
 


### PR DESCRIPTION
The previous benchmark used rather short files which made setup/teardown affect the results. I've now changed this to use an actual song, Like a Rolling Stone by Bob Dylan, with the downside that I cannot commit the song file to Git.

In order to run the benchmarks, you need to manually add a `fixtures/like-a-rolling-stone.pcm` file containing raw PCM data, 44.1kHz, little endian 16-bit, stereo. The below ffmpeg command can be used to convert the file to the correct format:

```sh
ffmpeg -i like-a-rolling-stone.flac -acodec pcm_s16le -ac 2 -ar 44100 -f s16le fixtures/like-a-rolling-stone.pcm
```

My hopes is that this new benchmark will better reflect real world usage of the library.