### PR TITLE
🎉 Use the bitvec crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ criterion = "^0.3.5"
 serde = { version = "^1.0.90", features = ["derive"] }
 
 [dependencies]
+bitvec = { version = "^1.0.0", default-features = false, features = ["alloc"] }
 log = "^0.4.14"
 
 [[bench]]

--- a/src/ag.rs
+++ b/src/ag.rs
@@ -67,7 +67,7 @@ fn dyn_code(bitstream: &mut BitBuffer, m: u32, k: u32, n: u32) {
 
         // use this result if coding this way is smaller than doing escape
         if num_bits <= (MAX_PREFIX_16 + MAX_DATATYPE_BITS_16) {
-            bitstream.write_lte25(value, num_bits as usize);
+            bitstream.write(value, num_bits as usize);
             return;
         }
     }
@@ -75,7 +75,7 @@ fn dyn_code(bitstream: &mut BitBuffer, m: u32, k: u32, n: u32) {
     let num_bits = MAX_PREFIX_16 + MAX_DATATYPE_BITS_16;
     let value = (((1 << MAX_PREFIX_16) - 1) << MAX_DATATYPE_BITS_16) + n;
 
-    bitstream.write_lte25(value, num_bits as usize);
+    bitstream.write(value, num_bits as usize);
 }
 
 #[inline(always)]
@@ -90,12 +90,12 @@ fn dyn_code_32bit(bitstream: &mut BitBuffer, maxbits: usize, m: u32, k: u32, n: 
         let value = (((1<<division)-1)<<(num_bits-division)) + modulo + 1 - de;
 
         if num_bits <= 25 {
-            bitstream.write_lte25(value, num_bits as usize);
+            bitstream.write(value, num_bits as usize);
             return;
         }
     }
 
-    bitstream.write_lte25((1 << MAX_PREFIX_32) - 1, MAX_PREFIX_32 as usize);
+    bitstream.write((1 << MAX_PREFIX_32) - 1, MAX_PREFIX_32 as usize);
     bitstream.write(n, maxbits);
 }
 

--- a/src/bit_buffer.rs
+++ b/src/bit_buffer.rs
@@ -1,57 +1,21 @@
+use bitvec::{slice::BitSlice, order::Msb0, view::BitView, field::BitField};
+
 pub struct BitBuffer<'a> {
-    pub buffer: &'a mut [u8],
+    pub slice: &'a mut BitSlice<u8, Msb0>,
     pub position: usize,
 }
 
 impl<'a> BitBuffer<'a> {
     pub fn new(buffer: &'a mut [u8]) -> BitBuffer<'a> {
-        BitBuffer { buffer, position: 0 }
+        BitBuffer { slice: buffer.view_bits_mut(), position: 0 }
     }
 
     pub fn len(&self) -> usize {
-        self.buffer.len()
-    }
-
-    pub fn write_lte25(&mut self, bit_values: u32, num_bits: usize) {
-        debug_assert!(num_bits > 0 && num_bits <= 25);
-        debug_assert!(self.position + num_bits <= self.buffer.len() * 8);
-
-        let target = unsafe { self.buffer.as_mut_ptr().add(self.position >> 3) as *mut u32 };
-        let shift = 32 - (self.position & 7) - num_bits;
-
-        let curr = u32::from_be(unsafe { core::ptr::read_unaligned(target) });
-
-        let mask = ((!0u32) >> (32 - num_bits)) << shift;
-        let main = ((bit_values << shift) & mask) | (curr & !mask);
-
-        unsafe { core::ptr::write_unaligned(target, main.to_be()); }
-
-        self.position += num_bits;
+        self.slice.len() / 8
     }
 
     pub fn write(&mut self, bit_values: u32, num_bits: usize) {
-        debug_assert!(num_bits > 0 && num_bits <= 32);
-        debug_assert!(self.position + num_bits <= self.buffer.len() * 8);
-
-        let target = unsafe { self.buffer.as_mut_ptr().add(self.position >> 3) as *mut u32 };
-        let shift = (32 - ((self.position as i32) & 7) - (num_bits as i32)) as i32;
-
-        let curr = u32::from_be(unsafe { core::ptr::read_unaligned(target) });
-
-        if shift < 0 {
-            let mask = (!0u32) >> -shift;
-            let main = (bit_values >> -shift) | (curr & !mask);
-            let tail = ((bit_values << (8 + shift)) & 0xff) as u8;
-
-            unsafe { core::ptr::write_unaligned(target, main.to_be()); }
-            unsafe { core::ptr::write_unaligned(target.offset(1) as *mut u8, tail); }
-        } else {
-            let mask = ((!0u32) >> (32 - num_bits)) << shift;
-            let main = ((bit_values << shift) & mask) | (curr & !mask);
-
-            unsafe { core::ptr::write_unaligned(target, main.to_be()); }
-        }
-
+        self.slice[self.position..(self.position + num_bits)].store_be(bit_values);
         self.position += num_bits;
     }
 
@@ -61,7 +25,7 @@ impl<'a> BitBuffer<'a> {
 
         if bit == 0 { return; }
 
-        self.write_lte25(0, 8 - bit);
+        self.write(0, 8 - bit);
     }
 
     pub fn position(&self) -> usize {


### PR DESCRIPTION
This removes a lot of unsafe code, but currently comes at quite a heavy performance cost unfortunately:

```text
Like a Rolling Stone    time:   [1.8420 s 1.8436 s 1.8456 s]                                    
                        change: [+79.128% +79.425% +79.742%] (p = 0.00 < 0.05)
                        Performance has regressed.
```